### PR TITLE
drivers: power: Add timeouts to wakelocks

### DIFF
--- a/drivers/power/supply/qcom/qpnp-fg-gen4.c
+++ b/drivers/power/supply/qcom/qpnp-fg-gen4.c
@@ -4825,7 +4825,7 @@ static int fg_awake_cb(struct votable *votable, void *data, int awake,
 	struct fg_dev *fg = data;
 
 	if (awake)
-		pm_stay_awake(fg->dev);
+		pm_wakeup_event(fg->dev, 500);
 	else
 		pm_relax(fg->dev);
 


### PR DESCRIPTION
These can get stuck sometimes and prevert system from sleeping.